### PR TITLE
Add instructions for styling slides via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ echo "# hi" | biggie > index.html
 Pipe it into [browser](https://gist.github.com/defunkt/318247) or [bcat](http://rtomayko.github.io/bcat/)
 to just view it in a browser immediately.
 
+### styling slides
+
+biggie can style your big presentation just the way you like it. To replace the
+default CSS provided by biggie, use the `--style` flag to point at a CSS file
+with your styles:
+
+```
+biggie my_presentation.md --style ./css/my_big_styles.css > index.html
+```
+
 ## develop
 
     git@github.com:tmcw/biggie.git


### PR DESCRIPTION
Hi Tom!

Thanks for putting this together. Long-time user of Big, and this is great for saving me even _more_ time! 👍 

I missed the look of the classic slides, and I had to do some code spelunking to figure out how to exercise the style functionality via the CLI.  Figured I would update the README and hopefully save others some time in the future.

Let me know if the language and punctuation doesn't jive with your aesthetic and I'll be happy to change it:
- Heading lower case
- Wrap text at 80 chars
- Code examples in triple-backtick blocks

Thanks,
--Andrew Pierce
